### PR TITLE
Adding a note about where this is deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run the application with `rackup`.
 
 ### On Cloud.gov
 
-Compliance Viewer is deployed to cloud.gov.
+The 18F instance of Compliance Viewer is deployed to cloud.gov in the `cf` organization and `toolkit` space.
 
 After doing a `cf push`, you will need to run:
 ```


### PR DESCRIPTION
The app has been moved out of my sandbox, into a more permanent cloud.gov home. This note updates the description.
