### PR TITLE
Travis CD and ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 credentials.yml
-config/development.yml
-config/production.yml
+env/development.json
 .rubocop-https---*
+.ruby-version
+.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: ruby
 rvm:
- - "2.2.3"
-script: ./go test
+  - 2.2.3
+script: "./go test"
 addons:
-    code_climate:
-        repo_token: 
-            secure: "fTCho/addJXdYFStTCQhEEXYtSo5PSwJWFSmyMa2S2+mBI/RHRobl9cXwLVIYx66L6abkzmUBLSCj1I0HaxwBQq/FcRIqaiCl0Zeip+4nyrAK8Hl27K2v0QZhW5kH9tlHIUfJuBlTtqeG9kzuzl9Dij8E3IXJnsbtTow94kgKu8CrDh3qrKUwViXn2QUcwhy364TIX10CgCp8z2VugdgxX4IPot8lc//oq/vyR3hVctV+juShmtkbQS3byMh8rkMFfAKoYUKfMgTdYdTkNMBMGrHHuE1vzGDdLEozV6sLORlOhX3878xrwJxwx/hxSVlgO+FKNp4Qq8ZB0xu32FFWEcWWOtSEiQ3TCU4u9sCUZiMR0hm/M5lruSg6POIZwzJFgBLMJAxmvdZNAOFvL5Z+LokpomACOP/wzKr1U1Aohg2k4X+nqUMMTFW2NnsRvKT31HILOPQNFMD/W9dnWQ9jxttH1TnYaDGvEBWYH0hHLz7AcHilU5gnAFZHReXBLIvnBSstjTK+HzgQm8fWzcRGq7L3IQOJllWSb5Eq/z/bm3dJ4ZIWtqJPpz2awTwFDbne7n/mx2HbQIGqSn/GvF+kKObN5vnWvLPGpHDAicl171xtQ5eYf4ZsJ8rXSmOzUlOV5pvVqAR6kJW4w56+J2aej454zsS/2OSaTrwou6lU58="
+  code_climate:
+    repo_token:
+      secure: fTCho/addJXdYFStTCQhEEXYtSo5PSwJWFSmyMa2S2+mBI/RHRobl9cXwLVIYx66L6abkzmUBLSCj1I0HaxwBQq/FcRIqaiCl0Zeip+4nyrAK8Hl27K2v0QZhW5kH9tlHIUfJuBlTtqeG9kzuzl9Dij8E3IXJnsbtTow94kgKu8CrDh3qrKUwViXn2QUcwhy364TIX10CgCp8z2VugdgxX4IPot8lc//oq/vyR3hVctV+juShmtkbQS3byMh8rkMFfAKoYUKfMgTdYdTkNMBMGrHHuE1vzGDdLEozV6sLORlOhX3878xrwJxwx/hxSVlgO+FKNp4Qq8ZB0xu32FFWEcWWOtSEiQ3TCU4u9sCUZiMR0hm/M5lruSg6POIZwzJFgBLMJAxmvdZNAOFvL5Z+LokpomACOP/wzKr1U1Aohg2k4X+nqUMMTFW2NnsRvKT31HILOPQNFMD/W9dnWQ9jxttH1TnYaDGvEBWYH0hHLz7AcHilU5gnAFZHReXBLIvnBSstjTK+HzgQm8fWzcRGq7L3IQOJllWSb5Eq/z/bm3dJ4ZIWtqJPpz2awTwFDbne7n/mx2HbQIGqSn/GvF+kKObN5vnWvLPGpHDAicl171xtQ5eYf4ZsJ8rXSmOzUlOV5pvVqAR6kJW4w56+J2aej454zsS/2OSaTrwou6lU58=
+deploy:
+  edge: true
+  provider: cloudfoundry
+  api: https://api.cloud.gov
+  username:
+  password:
+    secure:
+  organization: cf
+  space: toolkit
+  on:
+    repo: 18F/compliance-viewer
+    branch: develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ deploy:
   edge: true
   provider: cloudfoundry
   api: https://api.cloud.gov
-  username:
+  username: cf_toolkit_deployer
   password:
-    secure:
+    secure: "24M4FScTPzdK04XKkOLeY1wXeJptTx0FeB6jVE7Ar8Xo1iWhbVldEnuf/KNPu5OO602FroP2yBJN+zawC36wNW2Z/XRlOOUdmoIdLHu3QKK2iRz80utBr6Q4eh0xAE48rBgQecXcKO701JroKRyFbeuQj2shlTuNRJih+toayoD2xmV7SKO0z2aygmb1QMV1tVP9UEwApbbH6LhpfAV8DIXxQeQrh9BXuFiYZiReFDO+DqVBKHGraAwVy4U4hL0kJbMxKokWTCj6E3OjIm2EMY9vK9Hq3Dm+YxrS/LAc6DxAhSHrUCOBKYl76MCpsnv/MFFhlp1993ZlOpH06aBvpc9htqYo/cd66vaqkzkAXi8l6QivCz5Fw+9nr+e6pngQ6036+pOJ7DJxTIwPHZH+sWITgzbijV55gJm80uF9KYt9d3I3OzHpbAfOJqwjbBHr5PLAwMFQl0szvOk/zCTTtragSUYSo3+GdFIlhUKqNpHo1EGjXbAM4QEsNkqP7AZUb/uQ2AYrUqXylCpAZwEt2FDS0Df9t7l/rvQYcIVtYhAGOiPXMtqZ6gEsjFd18nWvIk3zwy1ZGsOTI+Dt8Z3yX1V/RX5y8lyTld4PZk+pzoss+B51/rgju3oY64vFIq0euNIXP8KoaC1COLZkhwB2Lgshz3X8WR91NUltxx38hIY="
   organization: cf
   space: toolkit
   on:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -11,22 +11,28 @@ A small application to access scan results stored in S3.
 
 ### Setup
 
-Compliance Viewer relies on MyUSA for access control. You will need to create an application at https://staging.my.usa.gov to get it running.
+Compliance Viewer relies on MyUSA for access control. You will need to **create an application** at https://staging.my.usa.gov to get it running.
 
-Create `config/production.yml` and `config/development.yml` based on the `config/example.yml`. This contains the configuration info for your AWS bucket as well as a few other application options.
+For your new application:
 
-### Locally
+1. The "Redirect uri" should be `https://<compliance-viewer-address>/auth/myusa/callback`.
+1. The "Email Address" checkbox under "Identify you by your email address" should be checked.
+1. Take note of the generated "MyUSA Consumer Public Key" and "MyUSA Consumer Secret Key".
 
-Create the following environment variables:
+### ENV
+#### Production
+We provide ENV variables via [User Provided Services](https://docs.cloudfoundry.org/devguide/services/user-provided.html). You can set them all interactively.
 
-`APP_ID`: MyUSA Consumer Public Key 
-`APP_SECRET`: MyUSA Consumer Secret Key 
-`COOKIE_SECRET`: A secret for your encrypted cookies.
+`cf cups compliance-viewer-env -p "app_id, app_secret, cookie_secret, aws_access_key, aws_secret_key, aws_bucket, aws_region, results_folder, results_format"`
 
-You can generate a good secret with:
-```
-ruby -rsecurerandom -e "puts SecureRandom.hex(32)"
-```
+The `cf env` command can be used to verify that ENV vars have been set.
+
+#### Locally
+User Provided Services expose values via CloudFoundry's `VCAP_SERVICES` ENV Variable, in JSON.  In development we mimic this.
+
+`cp env/example.json env/development.json` and fill out the required fields.  This JSON will be parsed the same way `VCAP_SERVICES` are parsed in production.
+
+Tip: you can generate a good `COOKIE_SECRET` with: `ruby -rsecurerandom -e "puts SecureRandom.hex(32)"`
 
 Run the application with `rackup`.
 
@@ -54,7 +60,7 @@ The `cf env` command will return the environment for `compliance-viewer`, includ
 ...
 ```
 
-You can update your credentials file with the first three pieces of information, and then re-push the app with `cf push`.
+You will need to set these values in the `compliance-viewer-env` User Provided Service.
 
 Alternatively, you can use an S3 bucket created directly via AWS.
 
@@ -64,15 +70,7 @@ aws s3api put-bucket-versioning --bucket BUCKET_NAME --versioning-configuration 
 ```
 or checked via:
 ```
-aws s3api get-bucket-versioning --bucket BUCKET_NAME 
-```
-
-To use MyUSA for authentication, you need to run:
-```
-cf set-env app-name APP_ID your_myusa_public_key
-cf set-env app-name APP_SECRET your_myusa_secret_key
-cf set-env app-name COOKIE_SECRET your_cookie_secret
-cf restage app-name 
+aws s3api get-bucket-versioning --bucket BUCKET_NAME
 ```
 
 ### Public domain

--- a/app.rb
+++ b/app.rb
@@ -30,26 +30,26 @@ class ComplianceViewer < Sinatra::Base
   end
 
   get '/' do
-    erb :index, locals: { projects: compliance_data.keys }
+    erb :index, locals: { projects: @compliance_data.keys }
   end
 
   get '/results' do
-    erb :index, locals: { projects: compliance_data.keys }
+    erb :index, locals: { projects: @compliance_data.keys }
   end
 
   get '/results/:name' do |name|
-    versions = compliance_data.versions name
+    versions = @compliance_data.versions(name)
     return 'Invalid Project' if versions.count == 0
     erb :results, locals: { versions: versions }
   end
 
   get '/results/:name/:version' do |name, version|
     version = nil if version == 'current'
-    file_data = compliance_data.file_for(name, version)
+    file_data = @compliance_data.file_for(name, version)
     if file_data
       if params['format'] == 'json'
         attachment "#{name}#{settings.results_format}"
-        compliance_data.json_for file_data
+        @compliance_data.json_for file_data
       else
         erb :report, locals: { report_data: ZapReport.create_report(file_data) }
       end

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,4 @@
 require 'sinatra/base'
-require 'sinatra/config_file'
 require 'sinatra/reloader'
 require 'json'
 require_relative 'lib/zap_report'
@@ -7,10 +6,7 @@ require_relative 'lib/compliance_data'
 
 class ComplianceViewer < Sinatra::Base
   attr_reader :compliance_data
-  register Sinatra::ConfigFile
   include ZapReport
-
-  config_file "config/#{settings.environment}.yml"
 
   helpers do
     def authed?
@@ -18,9 +14,9 @@ class ComplianceViewer < Sinatra::Base
     end
   end
 
-  def initialize(data = ComplianceData.new(settings))
+  def initialize
     super
-    @compliance_data = data
+    @compliance_data = ComplianceData.new
   end
 
   get '/auth/myusa/callback' do

--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,16 @@
 require 'bundler/setup'
 require 'omniauth-myusa'
 require 'encrypted_cookie'
+require './lib/vcap_env'
 require './app'
+
+# Set ENV from CloudFoundry UserProvidedService JSON when in production.
+#  In other envs use pre-configured JSON
+if ENV['RACK_ENV'] == 'production'
+  VcapEnv.set_env(ENV['VCAP_SERVICES'])
+else
+  VcapEnv.set_env(File.read("#{__dir__}/env/#{ENV['RACK_ENV']}.json"))
+end
 
 cookie_settings = {
   secret: ENV['COOKIE_SECRET'],

--- a/config/example.yml
+++ b/config/example.yml
@@ -1,6 +1,0 @@
-aws_access_key:
-aws_secret_key:
-aws_bucket:
-aws_region:
-results_folder:
-results_format:

--- a/config/test.yml
+++ b/config/test.yml
@@ -1,7 +1,0 @@
-aws_access_key: ACCESS_KEY
-aws_secret_key: SECRET_KEY 
-aws_bucket: BUCKET_NAME
-aws_region: REGION
-script_branch: BRANCH
-results_folder: results
-results_format: .json

--- a/env/example.json
+++ b/env/example.json
@@ -1,0 +1,19 @@
+{
+  "user-provided": [
+    {
+      "name": "compliance-viewer-env",
+      "label": "user-provided",
+      "credentials": {
+        "app_id": "<APP_ID>",
+        "app_secret": "<APP_SECRET>",
+        "aws_access_key": "<AWS_ACCESS_KEY>",
+        "aws_bucket": "<AWS_BUCKET>",
+        "aws_region": "<AWS_REGION>",
+        "aws_secret_key": "<AWS_SECRET_KEY>",
+        "cookie_secret": "<COOKIE_SECRET>",
+        "results_folder": "<RESULTS_FOLDER>",
+        "results_format": "<RESULTS_FORMAT>"
+      }
+    }
+  ]
+}

--- a/lib/compliance_data.rb
+++ b/lib/compliance_data.rb
@@ -1,29 +1,26 @@
 require 'aws-sdk'
 
 class ComplianceData
-  attr_reader :bucket, :settings
-
-  def initialize(settings)
-    raise ArgumentError if settings.nil?
+  def initialize
     Aws.config.update(
-      region: settings.aws_region,
-      credentials: Aws::Credentials.new(settings.aws_access_key,
-                                        settings.aws_secret_key))
-    @settings = settings
-    @bucket = Aws::S3::Bucket.new(settings.aws_bucket)
+      region: ENV['AWS_REGION'],
+      credentials: Aws::Credentials.new(ENV['AWS_ACCESS_KEY'], ENV['AWS_SECRET_KEY'])
+    )
+
+    @bucket = Aws::S3::Bucket.new(ENV['AWS_BUCKET'])
   end
 
   def base_name(full_name)
-    File.basename (full_name || ''), @settings.results_format
+   File.basename (full_name || ''), ENV['RESULTS_FORMAT']
   end
 
   def full_name(base_name)
-    return '' if base_name.nil?
-    "#{@settings.results_folder}/#{base_name}#{@settings.results_format}"
+   return '' if base_name.nil?
+   "#{ENV['RESULTS_FOLDER']}/#{base_name}#{ENV['RESULTS_FORMAT']}"
   end
 
   def keys
-    projects = @bucket.objects(prefix: @settings.results_folder) || []
+    projects = @bucket.objects(prefix: ENV['RESULTS_FOLDER']) || []
     projects.map do |project|
       base_name(project.key)
     end

--- a/lib/compliance_data.rb
+++ b/lib/compliance_data.rb
@@ -1,6 +1,8 @@
 require 'aws-sdk'
 
 class ComplianceData
+  attr_reader :bucket
+  
   def initialize
     Aws.config.update(
       region: ENV['AWS_REGION'],

--- a/lib/vcap_env.rb
+++ b/lib/vcap_env.rb
@@ -1,0 +1,13 @@
+require 'json'
+
+# Parses ENV['VCAP_SERVICES'] or similar JSON and sets ENV variables for user-provided:credentials
+module VcapEnv
+  def self.set_env(vcap_json)
+    vcap = JSON.parse(vcap_json)
+    env = vcap["user-provided"].find { |service| service["name"] == "compliance-viewer-env"  }
+
+    env["credentials"].each_pair do |name, value|
+      ENV[name.upcase] = value
+    end
+  end
+end

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,16 @@
 ---
 applications:
-- name: compliance-viewer 
-  memory: 512M
+#- name: compliance-viewer
+- name: ct-dev-compliance-viewer
+  #memory: 512M
+  memory: 64M
   instances: 1
-  domain: 18f.gov
-  host: compliance-viewer
+  #domain: 18f.gov
+  #host: compliance-viewer
   services:
-    - s3-compliance-toolkit 
-  command: rackup -p $PORT -E production 
+    #- s3-compliance-toolkit
+    - ct_dev
+    # The following services are User Provided, and function as ENV vars.
+    - dev-compliance-viewer-env
+    # - compliance-viewer-env
+  command: rackup -p $PORT -E development

--- a/spec/compliance_data_spec.rb
+++ b/spec/compliance_data_spec.rb
@@ -2,39 +2,42 @@ require 'spec_helper'
 require 'stub_classes'
 
 describe ComplianceData do
+  before(:all) do
+    set_test_env
+  end
+
+  after(:all) do
+    unset_test_env
+  end
+
   describe '#initialize' do
     it 'returns a correctly constructed ComplianceData' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       expect(data).to be_an_instance_of ComplianceData
-      expect(data.settings).to eq StubClasses::StubSettings
-    end
-
-    it 'raises an argument error if settings are not correct' do
-      expect { ComplianceData.new nil }.to raise_error 'ArgumentError'
     end
   end
 
   describe '#base_name' do
     it 'returns correct output if given good input' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       base = data.base_name 'path/to/file.json'
       expect(base).to eq 'file'
     end
 
     it 'handles a missing extension' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       base = data.base_name 'path/to/file'
       expect(base).to eq 'file'
     end
 
     it 'handles a base name' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       base = data.base_name 'file'
       expect(base).to eq 'file'
     end
 
     it 'returns empty string if passed nil' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       base = data.base_name nil
       expect(base).to eq ''
     end
@@ -42,13 +45,13 @@ describe ComplianceData do
 
   describe '#full_name' do
     it 'returns correct output if given good input' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       full = data.full_name 'file'
       expect(full).to eq 'results/file.json'
     end
 
     it 'returns an empty string if passed nil' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       full = data.full_name nil
       expect(full).to eq ''
     end
@@ -56,21 +59,21 @@ describe ComplianceData do
 
   describe '#keys' do
     it 'retrieves correct output if given good input' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       expect(data.bucket).to receive(:objects)
         .and_return(
           [
             StubClasses::StubObjectSummary.new(
-              "#{StubClasses::StubSettings.results_folder}/abc"),
+              "#{ENV['RESULTS_FOLDER']}/abc"),
             StubClasses::StubObjectSummary.new(
-              "#{StubClasses::StubSettings.results_folder}/bcd")
+              "#{ENV['RESULTS_FOLDER']}/bcd")
           ])
       projects = data.keys
       expect(projects).to eq %w(abc bcd)
     end
 
     it 'returns an empty list if no results returned from AWS' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       expect(data.bucket).to receive(:objects).and_return(nil)
       projects = data.keys
       expect(projects).to eq []
@@ -79,7 +82,7 @@ describe ComplianceData do
 
   describe '#versions' do
     it 'retrieves the correct output, if given good input' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       expect(data.bucket).to receive(:object_versions)
         .and_return(%w(abc bcd))
       projects = data.versions 'test'
@@ -95,7 +98,7 @@ describe ComplianceData do
           get_object: { body: body_value }
         }
       }
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       file = data.file_for 'name', 'version'
       expect(file.body.string).to eq body_value
     end
@@ -107,7 +110,7 @@ describe ComplianceData do
           get_object: { body: body_value }
         }
       }
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       file = data.file_for 'name', nil
       expect(file.body.string).to eq body_value
     end
@@ -118,7 +121,7 @@ describe ComplianceData do
           get_object: 'NoSuchKey'
         }
       }
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       file = data.file_for 'name', nil
       expect(file).to eq nil
     end
@@ -126,13 +129,13 @@ describe ComplianceData do
 
   describe '#json_for' do
     it 'retrieves the expected json if given good input' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       file = StubClasses::StubFile.new('data' => 'abc')
       expect(data.json_for(file)).to eq '{"data":"abc"}'
     end
 
     it 'returns nil if nil passed in' do
-      data = ComplianceData.new StubClasses::StubSettings
+      data = ComplianceData.new
       expect(data.json_for(nil)).to eq nil
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,4 +50,14 @@ RSpec.configure do |config|
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
   end
+
+  def set_test_env
+    VcapEnv.set_env(File.read("#{__dir__}/test-env.json"))
+  end
+
+  def unset_test_env
+    ENV['APP_ID'] = ENV['APP_SECRET'] = ENV['AWS_ACCESS_KEY'] = ENV['AWS_BUCKET'] \
+      = ENV['AWS_REGION'] = ENV['AWS_SECRET_KEY'] = ENV['COOKIE_SECRET'] \
+      = ENV['RESULTS_FOLDER'] = ENV['RESULTS_FORMAT'] = nil
+  end
 end

--- a/spec/stub_classes.rb
+++ b/spec/stub_classes.rb
@@ -47,29 +47,4 @@ module StubClasses
     end
   end
 
-  module StubSettings
-    def self.aws_region
-      'region'
-    end
-
-    def self.aws_access_key
-      '123'
-    end
-
-    def self.aws_secret_key
-      '234'
-    end
-
-    def self.aws_bucket
-      "bucket#{rand(100)}"
-    end
-
-    def self.results_format
-      '.json'
-    end
-
-    def self.results_folder
-      'results'
-    end
-  end
 end

--- a/spec/test-env.json
+++ b/spec/test-env.json
@@ -1,0 +1,19 @@
+{
+  "user-provided": [
+    {
+      "name": "compliance-viewer-env",
+      "label": "user-provided",
+      "credentials": {
+        "app_id": "000",
+        "app_secret": "234",
+        "aws_access_key": "123",
+        "aws_bucket": "bucket22",
+        "aws_region": "region",
+        "aws_secret_key": "234",
+        "cookie_secret": "999",
+        "results_folder": "results",
+        "results_format": ".json"
+      }
+    }
+  ]
+}

--- a/spec/vcap_env_spec.rb
+++ b/spec/vcap_env_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require_relative '../lib/vcap_env'
+
+describe VcapEnv do
+  def vcap_json
+    %(
+    {
+      "user-provided": [
+        {
+          "name": "compliance-viewer-env",
+          "label": "user-provided",
+          "credentials": {
+            "app_id": "11235813",
+            "app_secret": "*lips=zipped*",
+            "aws_access_key": "123/abc+456&def",
+            "aws_bucket": "cloud.gov-bucket-names/are+long",
+            "aws_region": "us-east-1",
+            "aws_secret_key": "shhhhhhhhhhhhh",
+            "cookie_secret": "don'toverbakethem",
+            "results_folder": "results",
+            "results_format": ".json"
+          }
+        }
+      ]
+    }
+    )
+  end
+
+  describe 'test_vcap_json' do
+    it 'can be parsed' do
+      expect JSON.parse(vcap_json)
+    end
+  end
+
+  describe 'set_env' do
+    it 'should have an empty ENV before calling' do
+      expect(ENV['APP_ID']).to be nil
+      expect(ENV['AWS_REGION']).to be nil
+    end
+
+    it 'parses VCAP_ENV JSON and sets ENV with values' do
+      VcapEnv.set_env(vcap_json)
+      expect(ENV['APP_ID']).to eq "11235813"
+      expect(ENV['AWS_REGION']).to eq "us-east-1"
+      expect(ENV['AWS_ACCESS_KEY']).to eq "123/abc+456&def"
+      expect(ENV['COOKIE_SECRET']).to eq "don'toverbakethem"
+      expect(ENV['RESULTS_FORMAT']).to eq ".json"
+    end
+  end
+
+end

--- a/spec/vcap_env_spec.rb
+++ b/spec/vcap_env_spec.rb
@@ -33,7 +33,7 @@ describe VcapEnv do
   end
 
   describe 'set_env' do
-    it 'should have an empty ENV before calling' do
+    it 'should have an empty ENV when this test starts' do
       expect(ENV['APP_ID']).to be nil
       expect(ENV['AWS_REGION']).to be nil
     end


### PR DESCRIPTION
Use Travis for ContinuousDeployment
Use CloudFoundry UserProvidedServices for ENV

I tested this by adjusting things locally to point to my sandbox in cloud.gov.

Getting this out there for feedback even though:
Still TODO:
- [x] create a real deploy user for the production compliance-viewer app
- [x] fix all the broken tests

Thoughts on just using JSON to populate ENV vars in dev env?
