### PR TITLE
redirect the /results page to the home page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -58,7 +58,7 @@ class ComplianceViewer < Sinatra::Base
   end
 
   get '/results' do
-    erb :index, locals: { projects: @compliance_data.keys }
+    redirect '/'
   end
 
   get '/results/:name' do |name|
@@ -81,6 +81,4 @@ class ComplianceViewer < Sinatra::Base
       'Invalid Version'
     end
   end
-
-
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -39,19 +39,10 @@ describe 'ComplianceViewer' do
   end
 
   describe '/results' do
-    it 'returns as expected with the index if authed' do
-      ComplianceData.any_instance.stubs(:keys).returns(%w(abc bcd))
-      get '/results', {},
-          'rack.session' => { user_email: 'example@example.com' }
-      expect(last_response).to be_ok
-      expect(last_response.body).to include('Projects')
-      ComplianceData.any_instance.unstub(:keys)
-    end
-
-    it 'redirects to the auth page if unauthed' do
-      get '/results'
+    it "redirects to the home page" do
+      get '/results', {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response.redirect?).to eq true
-      expect(last_response['Location']).to include('/auth/myusa')
+      expect(last_response['Location']).to eq('http://example.org/')
     end
   end
 


### PR DESCRIPTION
No need to have two URLs that do the same thing.
