### PR TITLE
Deploy from travis was failing. This fixes it.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
-buildpack: "https://github.com/ozzyjohnson/heroku-buildpack-multi.git"
+buildpack: ruby_buildpack
 applications:
 - name: compliance-viewer
   memory: 512M
@@ -9,4 +9,5 @@ applications:
   services:
     - s3-compliance-toolkit
     - compliance-viewer-env # This service is User Provided, and functions as ENV vars.
-  command: bin/run.sh 
+  command: rackup -p $PORT -E production
+


### PR DESCRIPTION
The manifest file was still referencing the multi-buildpack instead of the ruby one. That was causing the travis deployments to fail. This will allow the deploys to succeed.
