### PR TITLE
Hide table and show message when there are no scan errors

### DIFF
--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -1,8 +1,8 @@
 
 $cg-blue: #1f2c38;
 
-.usa-alert {
-  background-position: 1rem 1rem;
+.usa-alert-all-passing {
+  background-image: none;
 }
 
 .usa-disclaimer {

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -1,6 +1,10 @@
 
 $cg-blue: #1f2c38;
 
+.usa-alert {
+  background-position: 1rem 1rem;
+}
+
 .usa-disclaimer {
   color: black;
 }

--- a/views/report.erb
+++ b/views/report.erb
@@ -29,22 +29,33 @@
     </a>
   </div>
   <p class="updated_at">Updated <time class="js-time-human-readable" datetime="<%= project_time %>"><%= project_time %></time></p>
-  <table class="alerts-table js-table-sortable">
-    <thead>
-      <tr>
-        <th class="alerts-table_type" data-sort="string" scope="col">Type</th>
-        <th class="alerts-table_risk" data-sort="string" scope="col">Risk (Confidence)</th>
-        <th scope="col">Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% for alert, alert_data in report_data['alerts'] %>
+
+  <% if alert_count == 0 %>
+    <div class="usa-alert usa-alert-success">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Success</h3>
+        <p class="usa-alert-text">All scans passing</p>
+      </div>
+    </div>
+  <% else %>
+    <table class="alerts-table js-table-sortable">
+      <thead>
         <tr>
-          <td><%= alert %></td>
-          <td><%= alert_data['risk'] %> (<%= alert_data['confidence'] %>)</td>
-          <td><%= alert_data['description'] %></td>
+          <th class="alerts-table_type" data-sort="string" scope="col">Type</th>
+          <th class="alerts-table_risk" data-sort="string" scope="col">Risk (Confidence)</th>
+          <th scope="col">Description</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% for alert, alert_data in report_data['alerts'] %>
+          <tr>
+            <td><%= alert %></td>
+            <td><%= alert_data['risk'] %> (<%= alert_data['confidence'] %>)</td>
+            <td><%= alert_data['description'] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
 </div>

--- a/views/report.erb
+++ b/views/report.erb
@@ -31,11 +31,8 @@
   <p class="updated_at">Updated <time class="js-time-human-readable" datetime="<%= project_time %>"><%= project_time %></time></p>
 
   <% if alert_count == 0 %>
-    <div class="usa-alert usa-alert-success">
-      <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">Success</h3>
-        <p class="usa-alert-text">All scans passing</p>
-      </div>
+    <div class="usa-alert usa-alert-success usa-alert-all-passing">
+      <p class="usa-alert-text">All scans passing</p>
     </div>
   <% else %>
     <table class="alerts-table js-table-sortable">


### PR DESCRIPTION
Looks like this:

<img width="998" alt="screen shot 2016-05-03 at 11 15 06 am" src="https://cloud.githubusercontent.com/assets/697848/14990039/6239db74-1120-11e6-9c66-8825ab32c8f5.png">

Ready for review. Closes #38.
