### PR TITLE
use usa-alert styling for status bar

### DIFF
--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -1,5 +1,13 @@
-.usa-alert-all-passing {
+.usa-alert-no-icon {
   background-image: none;
+}
+
+.usa-alert-statusbar {
+  margin-bottom: 1.5rem;
+}
+
+.usa-alert__updated-at {
+  float: right;
 }
 
 .usa-disclaimer {
@@ -50,20 +58,6 @@
   }
 
   .projects-table_scan-summary {
-    float: right;
-  }
-}
-
-
-.statusbar {
-  background-color: #1f2c38;
-  color: #fff;
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-  padding: 1rem;
-  width: 100%;
-
-  .statusbar__updated_at {
     float: right;
   }
 }

--- a/views/report.erb
+++ b/views/report.erb
@@ -1,14 +1,18 @@
 
 <a href="/">&#8592; Project List Page</a>
 
-<div class="statusbar">
-  <% alert_count = report_data['alerts'].length %>
-  <% if alert_count == 0 %>
-    All scans passing
-  <% else %>
-    Scans returned <%= alert_count %> error<% if alert_count > 1 %>s<% end %>
-  <% end %>
-  <span class="statusbar__updated_at">Updated <time class="js-time-human-readable" datetime="<%= project_time %>"><%= project_time %></time></span>
+<% alert_count = report_data['alerts'].length %>
+<div class="usa-alert usa-alert-statusbar usa-alert-no-icon <%= alert_count == 0 ? 'usa-alert-success' : 'usa-alert-warning' %>">
+  <div class="usa-alert-text">
+    <p class="usa-alert-text">
+      <% if alert_count == 0 %>
+        All scans passing
+      <% else %>
+        Scans returned <%= alert_count %> error<% if alert_count > 1 %>s<% end %>
+      <% end %>
+      <span class="usa-alert__updated-at">Updated <time class="js-time-human-readable" datetime="<%= project_time %>"><%= project_time %></time></span>
+    </p>
+  </div>
 </div>
 
 <h1><%= project_name %></h1>
@@ -30,7 +34,7 @@
   </div>
   <p class="updated_at">Updated <time class="js-time-human-readable" datetime="<%= project_time %>"><%= project_time %></time></p>
   <% if alert_count == 0 %>
-    <div class="usa-alert usa-alert-success usa-alert-all-passing">
+    <div class="usa-alert usa-alert-success usa-alert-no-icon">
       <p class="usa-alert-text">All scans passing</p>
     </div>
   <% else %>


### PR DESCRIPTION
Minor change to the Report page to use `.usa-alert` classes for the status bar on the Reports page. 
When there are scan errors, the bar will be classed as `.usa-alert-warning`. When there are no errors, it will be `.usa-alert-success`.

Current:
<img width="1011" alt="screen shot 2016-05-05 at 3 36 24 pm" src="https://cloud.githubusercontent.com/assets/697848/15054719/dcaf0cfa-12d6-11e6-818d-1bfc667faae6.png">

This PR:
<img width="913" alt="screen shot 2016-05-05 at 3 37 53 pm" src="https://cloud.githubusercontent.com/assets/697848/15054766/12d577a6-12d7-11e6-9de8-aa5c740553b2.png">

and
<img width="895" alt="screen shot 2016-05-05 at 3 38 39 pm" src="https://cloud.githubusercontent.com/assets/697848/15054787/2daf5362-12d7-11e6-902a-f1603a5b77be.png">
