### PR TITLE
Removing the inherited rubocop config and correcting rubocop errors.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,29 @@
-inherit_from:
-- https://raw.githubusercontent.com/18F/concourse-compliance-testing/master/.rubocop.yml
+# Same as https://raw.githubusercontent.com/18F/concourse-compliance-testing/master/.rubocop.yml, but can not be inherited, because then it would require a network connection.
+AllCops:
+  Exclude:
+    - 'node_modules/**/*'
+Metrics/LineLength:
+  Enabled: false
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+Style/CommentAnnotation:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DotPosition:
+  Enabled: false
+Style/EmptyElse:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IfUnlessModifier:
+  # inline conditionals don't get picked up by simplecov, so preferable to avoid them
+  Enabled: false
+Style/IndentArray:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false

--- a/app.rb
+++ b/app.rb
@@ -46,7 +46,7 @@ class ComplianceViewer < Sinatra::Base
   end
 
   before do
-    cache_control :public, :must_revalidate, :max_age => 60
+    cache_control :public, :must_revalidate, max_age: 60
   end
 
   get '/auth/myusa/callback' do

--- a/config.ru
+++ b/config.ru
@@ -19,11 +19,11 @@ use Rack::Session::EncryptedCookie, cookie_settings
 
 use OmniAuth::Builder do
   provider :myusa, creds.app_id, creds.app_secret,
-           scope: 'profile.email',
-           client_options: {
-             site: 'https://alpha.my.usa.gov',
-             token_url: '/oauth/token'
-           }
+    scope: 'profile.email',
+    client_options: {
+      site: 'https://alpha.my.usa.gov',
+      token_url: '/oauth/token'
+    }
 end
 
 map '/assets' do

--- a/lib/compliance_data.rb
+++ b/lib/compliance_data.rb
@@ -8,17 +8,16 @@ class ComplianceData
   def initialize
     @bucket = Aws::S3::Bucket.new(s3_credentials.bucket,
       region: user_credentials.aws_region,
-      credentials: Aws::Credentials.new(s3_credentials.access_key_id, s3_credentials.secret_access_key)
-    )
+      credentials: Aws::Credentials.new(s3_credentials.access_key_id, s3_credentials.secret_access_key))
   end
 
   def base_name(full_name)
-   File.basename (full_name || ''), '.json'
+    File.basename (full_name || ''), '.json'
   end
 
   def full_name(base_name)
-   return '' if base_name.nil?
-   "#{results_folder}/#{base_name}.json"
+    return '' if base_name.nil?
+    "#{results_folder}/#{base_name}.json"
   end
 
   def s3_result_objects

--- a/lib/zap_summary.rb
+++ b/lib/zap_summary.rb
@@ -24,6 +24,6 @@ class ZapSummary
   def self.from_s3_object(s3_object)
     name = File.basename(s3_object.key, '.json')
     data = JSON.load(s3_object.get.body)
-    self.new(name, data)
+    new(name, data)
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -57,8 +57,7 @@ describe 'ComplianceViewer' do
           StubClasses::StubObjectVersion.new(name)
         ])
       )
-      get "/results/#{name}", {},
-          'rack.session' => { user_email: 'example@example.com' }
+      get "/results/#{name}", {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response).to be_ok
       expect(last_response.body).to include(name)
       ComplianceData.any_instance.unstub(:base_name)
@@ -68,8 +67,7 @@ describe 'ComplianceViewer' do
     it 'returns Invalid Project if passed a name that doesn\'t exist' do
       ComplianceData.any_instance.stubs(:versions).returns(
         StubClasses::StubCollection.new)
-      get "/results/name", {},
-          'rack.session' => { user_email: 'example@example.com' }
+      get "/results/name", {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response).to be_ok
       expect(last_response.body).to include('Invalid Project')
       ComplianceData.any_instance.unstub(:versions)
@@ -92,8 +90,7 @@ describe 'ComplianceViewer' do
     it 'returns successfully if passed a name and version that exists' do
       ComplianceData.any_instance.stubs(:file_for).returns(
         StubClasses::StubFile.new)
-      get "/results/good/good", {},
-          'rack.session' => { user_email: 'example@example.com' }
+      get "/results/good/good", {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response).to be_ok
       ComplianceData.any_instance.unstub(:file_for)
     end
@@ -101,8 +98,7 @@ describe 'ComplianceViewer' do
     it 'returns successfully in JSON' do
       ComplianceData.any_instance.stubs(:file_for).returns(
         StubClasses::StubFile.new)
-      get "/results/good/good?format=json", {},
-          'rack.session' => { user_email: 'example@example.com' }
+      get "/results/good/good?format=json", {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response).to be_ok
       ComplianceData.any_instance.unstub(:file_for)
     end
@@ -110,16 +106,14 @@ describe 'ComplianceViewer' do
     it 'returns successfully if passed a name and current version' do
       ComplianceData.any_instance.stubs(:file_for).returns(
         StubClasses::StubFile.new)
-      get "/results/good/current", {},
-          'rack.session' => { user_email: 'example@example.com' }
+      get "/results/good/current", {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response).to be_ok
       ComplianceData.any_instance.unstub(:file_for)
     end
 
     it 'returns Invalid Version if passed a version that doesn\'t exist' do
       ComplianceData.any_instance.stubs(:file_for).returns nil
-      get '/results/good/bad', {},
-          'rack.session' => { user_email: 'example@example.com' }
+      get '/results/good/bad', {}, 'rack.session' => { user_email: 'example@example.com' }
       expect(last_response).to be_ok
       expect(last_response.body).to include('Invalid Version')
       ComplianceData.any_instance.unstub(:file_for)

--- a/spec/stub_classes.rb
+++ b/spec/stub_classes.rb
@@ -47,5 +47,4 @@ module StubClasses
       @items.each(&block)
     end
   end
-
 end

--- a/spec/zap_summary_spec.rb
+++ b/spec/zap_summary_spec.rb
@@ -5,8 +5,7 @@ describe ZapSummary do
         'high' => 0,
         'medium' => 2,
         'low' => 7,
-        'informational' => 8
-      )
+        'informational' => 8)
       expect(summary.top_level).to eq('medium')
     end
 
@@ -15,8 +14,7 @@ describe ZapSummary do
         'high' => 0,
         'medium' => 0,
         'low' => 0,
-        'informational' => 0
-      )
+        'informational' => 0)
       expect(summary.top_level).to eq(nil)
     end
   end


### PR DESCRIPTION
Closes #49. Inheriting rubocop config requires a network connection, which won't work for CodeClimate-run linters. This moves the config locally. Also cleans up the existing rubocop warnings.
