### PR TITLE
Trello => ZenHub

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -4,7 +4,7 @@
     The Compliance Viewer aims to make the Authority to Operate (ATO) process and regulatory compliance more tangible, actionable, and transparent for everyone involved.
   </p>
   <p>
-    To do this, it automates the parts of the compliance process that can be automated — namely, scanning web applications — and helps with those that require a human touch. As the project evolves, its scope will expand to include much more than app scanning. For more on what we’ve got planned, check out our <a href="https://trello.com/b/QYPc32q1/compliance-toolkit">backlog</a>.
+    To do this, it automates the parts of the compliance process that can be automated — namely, scanning web applications — and helps with those that require a human touch. As the project evolves, its scope will expand to include much more than app scanning. For more on what we’ve got planned, check out our <a href="https://www.zenhub.io/">ZenHub</a> <a href="https://github.com/18F/compliance-toolkit#boards">backlog</a>.
   </p>
   <p>
     If your project appears on the list below, click its name to view the latest compliance results. If it’s not on the list, click the <a href="https://github.com/18F/concourse-compliance-testing#adding-a-project">New Project?</a> link to add it. For a walk through of the ATO process, visit the <a href="https://pages.18f.gov/before-you-ship/">Before You Ship</a> guide.

--- a/views/index.erb
+++ b/views/index.erb
@@ -4,7 +4,7 @@
     The Compliance Viewer aims to make the Authority to Operate (ATO) process and regulatory compliance more tangible, actionable, and transparent for everyone involved.
   </p>
   <p>
-    To do this, it automates the parts of the compliance process that can be automated — namely, scanning web applications — and helps with those that require a human touch. As the project evolves, its scope will expand to include much more than app scanning. For more on what we’ve got planned, check out our <a href="https://www.zenhub.io/">ZenHub</a> <a href="https://github.com/18F/compliance-toolkit#boards">backlog</a>.
+    To do this, it automates the parts of the compliance process that can be automated — namely, scanning web applications — and helps with those that require a human touch. As the project evolves, its scope will expand to include much more than app scanning. For more on what we’ve got planned, check out our <a href="https://github.com/18F/compliance-toolkit#boards">backlog</a> (<a href="https://www.zenhub.io/">ZenHub</a> extension required).
   </p>
   <p>
     If your project appears on the list below, click its name to view the latest compliance results. If it’s not on the list, click the <a href="https://github.com/18F/concourse-compliance-testing#adding-a-project">New Project?</a> link to add it. For a walk through of the ATO process, visit the <a href="https://pages.18f.gov/before-you-ship/">Before You Ship</a> guide.


### PR DESCRIPTION
Updating a link to our backlog from the deprecated Trello board to ZenHub.
