### PR TITLE
Update package.json with cg-style 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "cloudgov-style": "~0.4.0"
+    "cloudgov-style": "~0.5.0"
   },
   "devDependencies": {
     "eslint": "^2.9.0",


### PR DESCRIPTION
A new release of `cg-style` went out on June 10, 2016. This pull request updates to the latest version of `cg-style`.
